### PR TITLE
feat(tests): replaced `FluentAssertions` with `Shouldly`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,6 @@
     <PackageVersion Include="FastEndpoints" Version="5.33.0"/>
     <PackageVersion Include="FastEndpoints.AspVersioning" Version="5.33.0"/>
     <PackageVersion Include="FastEndpoints.Generator" Version="5.33.0"/>
-    <PackageVersion Include="FluentAssertions" Version="7.0.0"/>
     <PackageVersion Include="FluentResults" Version="3.16.0"/>
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0"/>
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.0"/>
@@ -36,6 +35,7 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.10.0"/>
     <PackageVersion Include="Respawn" Version="6.2.1"/>
     <PackageVersion Include="SecurityCodeScan.VS2019" Version="5.6.7"/>
+    <PackageVersion Include="Shouldly" Version="4.2.1"/>
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.5.0.109200"/>
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556"/>
     <PackageVersion Include="Testcontainers.MsSql" Version="4.1.0"/>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -5,13 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions"/>
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage"/>
     <PackageReference Include="NSubstitute"/>
     <PackageReference Include="NSubstitute.Analyzers.CSharp">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Shouldly"/>
     <PackageReference Include="TUnit"/>
     <PackageReference Include="Verify.TUnit"/>
   </ItemGroup>
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="FluentAssertions"/>
+    <Using Include="Shouldly"/>
     <Using Include="NSubstitute"/>
   </ItemGroup>
 </Project>

--- a/tests/TShort.Api.Tests.Integration/Endpoints/V1/GetRedirectsEndpointTests.cs
+++ b/tests/TShort.Api.Tests.Integration/Endpoints/V1/GetRedirectsEndpointTests.cs
@@ -42,7 +42,7 @@ public sealed class GetRedirectsEndpointTests(AlbaBootstrap albaBootstrap) : Alb
         var response = result.ReadAsJson<RedirectsResponse>();
 
         // Assert
-        response.Redirects.Should().HaveCount(1);
+        response.Redirects.ShouldHaveSingleItem();
         await Verify(response);
     }
 
@@ -81,7 +81,7 @@ public sealed class GetRedirectsEndpointTests(AlbaBootstrap albaBootstrap) : Alb
         var response = result.ReadAsJson<RedirectsResponse>();
 
         // Assert
-        response.Redirects.Should().HaveCount(2);
+        response.Redirects.Count.ShouldBe(2);
         await Verify(response);
     }
 }


### PR DESCRIPTION
While the new license for `Fluentassertions` is permissive for open-source projects, getting familiar with a replacement seems the more logical choice. In addition, the library was barely used due to a prevalence of snapshot testing.